### PR TITLE
Fix authentication success handler by setting the _target_path

### DIFF
--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -3,7 +3,7 @@
 /*
  * autoregistration extension for Contao Open Source CMS
  *
- * @copyright  Copyright (c) 2018, terminal42 gmbh
+ * @copyright  Copyright (c) 2020, terminal42 gmbh
  * @author     terminal42 gmbh <info@terminal42.ch>
  * @license    MIT
  * @link       http://github.com/terminal42/contao-autoregistration

--- a/src/DependencyInjection/Terminal42AutoRegistrationExtension.php
+++ b/src/DependencyInjection/Terminal42AutoRegistrationExtension.php
@@ -3,7 +3,7 @@
 /*
  * autoregistration extension for Contao Open Source CMS
  *
- * @copyright  Copyright (c) 2018, terminal42 gmbh
+ * @copyright  Copyright (c) 2020, terminal42 gmbh
  * @author     terminal42 gmbh <info@terminal42.ch>
  * @license    MIT
  * @link       http://github.com/terminal42/contao-autoregistration

--- a/src/Terminal42AutoRegistrationBundle.php
+++ b/src/Terminal42AutoRegistrationBundle.php
@@ -3,7 +3,7 @@
 /*
  * autoregistration extension for Contao Open Source CMS
  *
- * @copyright  Copyright (c) 2018, terminal42 gmbh
+ * @copyright  Copyright (c) 2020, terminal42 gmbh
  * @author     terminal42 gmbh <info@terminal42.ch>
  * @license    MIT
  * @link       http://github.com/terminal42/contao-autoregistration


### PR DESCRIPTION
The auto-login does not work in Contao 4.9 since the target path is missing in the request. Actually, the login is working, but the authentication success handler throws an error.

This fix sets the _target_path to the current request which inherits from the jumpTo defined in the module.

As you can see, I disabled the authentication success handler when jumpTo is null. Don't know if this is the best solution, but it will throw an error otherwise. Or can we set _target_path to an empty string?