### PR TITLE
Allow PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "forum": "https://community.contao.org"
     },
     "require": {
-        "php": "^7.1",
+        "php": "^7.1 || ^8.0",
         "contao/core-bundle": "^4.5",
         "doctrine/dbal": "^2.7",
         "psr/log": "^1.0",


### PR DESCRIPTION
Hey guys. I have tried this extension in my development environment under PHP 8.0 and have found no obvious issues, it worked as expected without any adjustments.

If you don't have any objections I'd invite you to allow using the extension with PHP 8?