### PR TITLE
Fixed Issue #16: Don't update tl_member:disable in Contao 5

### DIFF
--- a/src/EventListener/RegistrationListener.php
+++ b/src/EventListener/RegistrationListener.php
@@ -53,13 +53,11 @@ class RegistrationListener
             return;
         }
 
-        // ensure it works for both Contao 4.13 and 5.x
-        if (version_compare(ContaoCoreBundle::getVersion(), '5', '<')) {
-            $data['disable'] = '';
-            $this->connection->update('tl_member', ['disable' => ''], ['id' => $userId]);
-        }
+        $disableValue = version_compare(ContaoCoreBundle::getVersion(), '5', '<') ? '' : 0;
 
-        if ('login' === $module->reg_autoActivate) {
+        $affectedRows = $this->connection->update('tl_member', ['disable' => $disableValue], ['id' => $userId]);
+
+        if ('login' === $module->reg_autoActivate && $affectedRows > 0) {
             $this->loginUser($data['username']);
         }
     }

--- a/src/EventListener/RegistrationListener.php
+++ b/src/EventListener/RegistrationListener.php
@@ -40,7 +40,7 @@ class RegistrationListener
         private readonly UserCheckerInterface $userChecker,
         private readonly AuthenticationSuccessHandlerInterface $authenticationSuccessHandler,
     ) {
-	}
+    }
 
     /**
      * Within the registration process, log in the user if needed.

--- a/src/EventListener/RegistrationListener.php
+++ b/src/EventListener/RegistrationListener.php
@@ -39,7 +39,8 @@ class RegistrationListener
         private readonly RequestStack $requestStack,
         private readonly UserCheckerInterface $userChecker,
         private readonly AuthenticationSuccessHandlerInterface $authenticationSuccessHandler,
-    ) {}
+    ) {
+	}
 
     /**
      * Within the registration process, log in the user if needed.
@@ -54,7 +55,7 @@ class RegistrationListener
         }
 
         $disableValue = version_compare(ContaoCoreBundle::getVersion(), '5', '<') ? '' : 0;
-
+		$data['disable'] = $disableValue;
         $affectedRows = $this->connection->update('tl_member', ['disable' => $disableValue], ['id' => $userId]);
 
         if ('login' === $module->reg_autoActivate && $affectedRows > 0) {
@@ -103,7 +104,7 @@ class RegistrationListener
 
         $this->logger->log(
             LogLevel::INFO,
-            'User "' . $username . '" was logged in automatically',
+            'User "'.$username.'" was logged in automatically',
             ['contao' => new ContaoContext(__METHOD__, ContaoContext::ACCESS)],
         );
 


### PR DESCRIPTION
There is no need to update `disable` field in Contao 5.x since its false by default.
Fixes #16