### PR TITLE
Fix SQL error on registration

### DIFF
--- a/src/EventListener/RegistrationListener.php
+++ b/src/EventListener/RegistrationListener.php
@@ -37,8 +37,7 @@ class RegistrationListener
             return;
         }
 
-        $data['disable'] = false;
-        $affectedRows = $this->connection->update('tl_member', ['disable' => false], ['id' => $userId]);
+        $affectedRows = $this->connection->update('tl_member', ['disable' => 0], ['id' => $userId]);
 
         if ('login' === $module->reg_autoActivate && $affectedRows > 0) {
             $this->loginUser($data['username']);


### PR DESCRIPTION
This PR fixes the following error:

```
PDOException:
SQLSTATE[22007]: Invalid datetime format: 1366 Incorrect integer value: '' for column `c53`.`tl_member`.`disable` at row 1

  at vendor\doctrine\dbal\src\Driver\PDO\Statement.php:130
  at PDOStatement->execute(null)
     (vendor\doctrine\dbal\src\Driver\PDO\Statement.php:130)
  at Doctrine\DBAL\Driver\PDO\Statement->execute(null)
     (vendor\doctrine\dbal\src\Driver\Middleware\AbstractStatementMiddleware.php:69)
  at Doctrine\DBAL\Driver\Middleware\AbstractStatementMiddleware->execute(null)
     (vendor\doctrine\dbal\src\Logging\Statement.php:98)
  at Doctrine\DBAL\Logging\Statement->execute(null)
     (vendor\doctrine\dbal\src\Driver\Middleware\AbstractStatementMiddleware.php:69)
  at Doctrine\DBAL\Driver\Middleware\AbstractStatementMiddleware->execute(null)
     (vendor\symfony\doctrine-bridge\Middleware\Debug\DBAL3\Statement.php:70)
  at Symfony\Bridge\Doctrine\Middleware\Debug\DBAL3\Statement->execute()
     (vendor\doctrine\dbal\src\Connection.php:1212)
  at Doctrine\DBAL\Connection->executeStatement('UPDATE tl_member SET disable = ? WHERE id = ?', array(false, 22), array())
     (vendor\doctrine\dbal\src\Connection.php:782)
  at Doctrine\DBAL\Connection->update('tl_member', array('disable' => false), array('id' => 22))
     (vendor\terminal42\contao-autoregistration\src\EventListener\RegistrationListener.php:41)
```

Doctrine maps `false` to an empty string, that's why an integer needs to be used here instead.

This PR supersedes #17.