### PR TITLE
Specifiy the authenticator

### DIFF
--- a/src/EventListener/RegistrationListener.php
+++ b/src/EventListener/RegistrationListener.php
@@ -67,6 +67,6 @@ class RegistrationListener
             return;
         }
 
-        $this->security->login($user);
+        $this->security->login($user, 'contao.security.login_authenticator.contao_frontend');
     }
 }


### PR DESCRIPTION
Even with no additional authenticators installed, the following error will occur:

```
Symfony\Component\Security\Core\Exception\LogicException:
Too many authenticators were found for the current firewall "contao_frontend". You must provide an instance of "Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface" to login programmatically. The available authenticators for the firewall "contao_frontend" are "contao.security.login_authenticator.contao_frontend" ,"security.authenticator.remember_me.contao_frontend".

  at vendor\symfony\security-bundle\Security.php:197
  at Symfony\Bundle\SecurityBundle\Security->getAuthenticator(null, 'contao_frontend')
     (vendor\symfony\security-bundle\Security.php:128)
  at Symfony\Bundle\SecurityBundle\Security->login(object(FrontendUser))
     (vendor\terminal42\contao-autoregistration\src\EventListener\RegistrationListener.php:69)
```

This is because Contao already has multiple authenticators for its `contao_frontend` firewall. And as mentioned in https://github.com/terminal42/contao-autoregistration/pull/17#issuecomment-2820469204 there can be even more authenticators provided by the App or other extensions.

To fix this a specific authenticator needs to be specified - `contao.security.login_authenticator.contao_frontend` in this case.